### PR TITLE
SLF4J class not found: Error in the execution output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Project exclude paths
+/.gradle/
+/build/
+/build/classes/java/main/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'io.rest-assured:rest-assured:4.5.1'
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'org.slf4j:jul-to-slf4j:1.7.36'
+    implementation 'org.slf4j:slf4j-simple:1.7.36'
     implementation 'org.yaml:snakeyaml:1.30'
     implementation 'io.github.bonigarcia:webdrivermanager:5.0.3'
 }


### PR DESCRIPTION
SOlved this ugly error by adding the slf4j-simply into the dependency and also could add slf4j-nop if required