### PR TITLE
oneLessConfig: Minimizing config setup

### DIFF
--- a/node/selenium-node-mac.sh
+++ b/node/selenium-node-mac.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -jar node/selenium-server-4.8.1.jar standalone --selenium-manager true
+java -jar ../node/selenium-server-4.10.0.jar standalone --selenium-manager true

--- a/node/selenium-node-windows.bat
+++ b/node/selenium-node-windows.bat
@@ -1,1 +1,1 @@
-java -jar node/selenium-server-4.8.1.jar standalone --selenium-manager true
+java -jar node/selenium-server-4.10.0.jar standalone --selenium-manager true


### PR DESCRIPTION
Now we don't have to set
Browser_Under_Test=chrome;Browser_Endpoint=http://localhost:4444/wd/hub in Environment variable of config file.
It will default to the default value if nothing is specifies. As the default values are something where the node is trigerred or the browser is user.

Also added Utilization of DevTools