### PR TITLE
oneLessConfig: Minimizing config setup

### DIFF
--- a/node/selenium-node-mac.sh
+++ b/node/selenium-node-mac.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -jar node/selenium-server-4.8.1.jar standalone --selenium-manager true
+java -jar ../node/selenium-server-4.10.0.jar standalone --selenium-manager true

--- a/node/selenium-node-windows.bat
+++ b/node/selenium-node-windows.bat
@@ -1,1 +1,1 @@
-java -jar node/selenium-server-4.8.1.jar standalone --selenium-manager true
+java -jar node/selenium-server-4.10.0.jar standalone --selenium-manager true

--- a/src/main/java/automation/core/framework/TestHooks.java
+++ b/src/main/java/automation/core/framework/TestHooks.java
@@ -14,12 +14,14 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.http.ContentType;
 
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,8 +119,11 @@ public class TestHooks extends BaseStepDef {
     public void captureScreenshot(Scenario scenario) {
         TestContext testContext = getContextManager().getRequiredContext(TestContext.class);
         try {
-            if (testContext.isWebDriverInitialised()) {
-                LogEntries logEntries = testContext.getWebDriver().manage().logs().get(LogType.BROWSER);
+            WebDriver driver = testContext.getWebDriver();
+            Capabilities capabilities = ((RemoteWebDriver) driver).getCapabilities();
+
+            if (testContext.isWebDriverInitialised() && !capabilities.getBrowserName().equals("firefox")) {
+                LogEntries logEntries = driver.manage().logs().get(LogType.BROWSER);
                 for (LogEntry entry : logEntries) {
                     logger.info("{}, {}, {}", new Date(entry.getTimestamp()), entry.getLevel(), entry.getMessage());
                 }

--- a/src/main/java/automation/selenium/BrowserProvider.java
+++ b/src/main/java/automation/selenium/BrowserProvider.java
@@ -20,7 +20,10 @@ public enum BrowserProvider {
         @Override
         public FirefoxOptions createCapabilities() {
             FirefoxOptions firefoxOptions = new FirefoxOptions();
-            firefoxOptions.setCapability("TakesScreenshot", true);
+            firefoxOptions.addArguments("--test-type");
+            firefoxOptions.addArguments("--disable-blink-features");
+            firefoxOptions.addArguments("--disable-blink-features=AutomationControlled");
+            firefoxOptions.setCapability("moz:webdriverClick", true);
             return firefoxOptions;
         }
 


### PR DESCRIPTION
Now we don't have to set
Browser_Under_Test=chrome;Browser_Endpoint=http://localhost:4444/wd/hub in Environment variable of config file.
It will default to the default value if nothing is specifies. As the default values are something where the node is trigerred or the browser is user.

Also added Utilization of DevTools